### PR TITLE
Add auth and fix dark mode

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,18 @@
+# Your StatelyDB credentials.
+STATELY_CLIENT_ID=
+STATELY_CLIENT_SECRET=
+
+# Your Stately Store ID. Note that this needs to be the same ID as the one that
+# was used for any schema commands.
+STATELY_STORE_ID=
+
+# Set to be the URL of your Next.js app (e.g. http://localhost:3000).
+NEXTAUTH_URL=
+
+# Google OAuth credentials. 
+# See: https://next-auth.js.org/providers/google
+AUTH_GOOGLE_ID=
+AUTH_GOOGLE_SECRET=
+
+# Add using `npx auth`. Read more: https://cli.authjs.dev
+AUTH_SECRET=

--- a/.env.local.example
+++ b/.env.local.example
@@ -6,7 +6,7 @@ STATELY_CLIENT_SECRET=
 # was used for any schema commands.
 STATELY_STORE_ID=
 
-# Set to be the URL of your Next.js app (e.g. http://localhost:3000).
+# Set to be the URL of your Next.js app (e.g. http://localhost:3000 or https://myapp.vercel.app).
 NEXTAUTH_URL=
 
 # Google OAuth credentials. 

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 
 # env files (can opt-in for commiting if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FStatelyCloud%2Fvercel-starter-template&env=STATELY_STORE_ID,STATELY_CLIENT_SECRET,STATELY_CLIENT_SECRET&envDescription=API%20keys%20and%20Store%20configuration.&envLink=https%3A%2F%2Fdocs.stately.cloud%2Fguides%2Fconnect%2F&skippable-integrations=1)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FStatelyCloud%2Fvercel-starter-template&env=STATELY_STORE_ID,STATELY_CLIENT_SECRET,STATELY_CLIENT_SECRET,NEXTAUTH_URL,AUTH_SECRET,AUTH_GOOGLE_ID,AUTH_GOOGLE_SECRET&envDescription=API%20keys%20and%20Store%20configuration.&envLink=https%3A%2F%2Fdocs.stately.cloud%2Fguides%2Fconnect%2F&skippable-integrations=1)
 
 # Vercel GoLinks
 
 This is a sample NextJS webapp that uses StatelyDB.
+
+*NOTE:* You MUST set up your StatelyDB store and schema following the instructions below before deploying to Vercel!
 
 ## Features
 
@@ -10,16 +12,13 @@ This is a sample NextJS webapp that uses StatelyDB.
 - Create and manage go-links (short string to URL associations)
 - Redirect to the associated URL when visiting a go-link path
 - Display a list of all go-links, ordered by most recently created
+- Uses Google OAuth to authenticate users. Each `GoLink` Item in the StatelyDB store belongs to a user.
 
 ## Prerequisites
 
 - Node.js 14.x or later
 - Vercel account
 - Stately Cloud account and access to a StatelyDB Store
-
-## What Isn't Included
-
-- This sample app doesn't include any auth and assumes a single user.
 
 ## Setup
 
@@ -28,13 +27,25 @@ This is a sample NextJS webapp that uses StatelyDB.
    ```
    npm install
    ```
-3. For local development, create a `.env.local` file in the root directory with the following content:
+3. Follow the instructions below under _StatelyDB Schema Setup_ to configure your StatelyDB Store and associated schema.
+4. This project uses [NextAuth.js](https://next-auth.js.org/) for authentication. You will need to [configure Google OAuth credentials](https://next-auth.js.org/providers/google).
+5. You will need to generate a secret value for the [`AUTH_SECRET`](https://next-auth.js.org/configuration/options#nextauth_secret) value:
+   ```
+   npx auth secret
+   ```
+6. For local development, create a `.env.local` file in the root directory with the following content:
    ```
    STATELY_CLIENT_ID=your_client_id
    STATELY_CLIENT_SECRET=your_client_secret
    STATELY_STORE_ID=12345
+   NEXTAUTH_URL=your_base_url
+   AUTH_GOOGLE_ID=your_google_oauth_id
+   AUTH_GOOGLE_SECRET=your_google_oauth_secret
+   AUTH_SECRET=your_auth_secret
    ```
-   Replace `your_client_id`, `your_client_secret`, and `12345` with your actual StatelyDB credentials and store ID.
+   Replace `your_client_id`, `your_client_secret`, and `12345` with your actual StatelyDB credentials and store ID.  Replace `your_base_url` with the base url of your app (e.g. `http://localhost:3000` or `https://myapp.vercel.app`).
+   
+   See `.env.local.example` for more details on the other configuration options.
 
 ## StatelyDB Schema Setup
 
@@ -92,9 +103,6 @@ Open [http://localhost:3000](http://localhost:3000) in your browser to see the a
    vercel
    ```
 4. Follow the prompts to configure your project
-5. Set up environment variables in the Vercel dashboard:
-   - STATELY_CLIENT_ID
-   - STATELY_CLIENT_SECRET
-   - STATELY_STORE_ID
+5. Set up environment variables in the Vercel dashboard
 
 Your application is now deployed and ready to use!

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,10 @@
         "@types/react-dom": "^18.0.11",
         "autoprefixer": "^10.4.14",
         "next": "^15.0.1",
+        "next-auth": "^5.0.0-beta.25",
         "postcss": "^8.4.21",
-        "react": "19.0.0-rc-69d4b800-20241021",
-        "react-dom": "19.0.0-rc-69d4b800-20241021",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "tailwindcss": "^3.3.1",
         "typescript": "^5.0.4"
       },
@@ -43,6 +44,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.2.tgz",
+      "integrity": "sha512-kUvzyvkcd6h1vpeMAojK2y7+PAV5H+0Cc9+ZlKYDFhDY31AlvsB+GW5vNO4qE3Y07KeQgvNO9U0QUx/fN62kBw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "@types/cookie": "0.6.0",
+        "cookie": "0.7.1",
+        "jose": "^5.9.3",
+        "oauth4webapi": "^3.0.0",
+        "preact": "10.11.3",
+        "preact-render-to-string": "5.2.3"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -1300,6 +1332,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1368,6 +1409,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2255,6 +2302,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -4171,11 +4227,19 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4329,7 +4393,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4500,6 +4563,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.25",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.25.tgz",
+      "integrity": "sha512-2dJJw1sHQl2qxCrRk+KTQbeH+izFbGFPuJj5eGgBZFYyiYYtvlrBeUw1E/OJJxTRjuxbSYGnCTkUIRsIIW0bog==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.37.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0-0",
+        "nodemailer": "^6.6.5",
+        "react": "^18.2.0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -4551,6 +4641,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.1.2.tgz",
+      "integrity": "sha512-KQZkNU+xn02lWrFu5Vjqg9E81yPtDSxUZorRHlLWVoojD+H/0GFbH59kcnz5Thdjj7c4/mYMBPj/mhvGe/kKXA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {
@@ -5026,6 +5125,28 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5035,6 +5156,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5080,24 +5207,28 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.0.0-rc-69d4b800-20241021",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0-rc-69d4b800-20241021.tgz",
-      "integrity": "sha512-dXki4tN+rP+4xhsm65q/QI/19VCZdu5vPcy4h6zaJt20XP8/1r/LCwrLFYuj8hElbNz5AmxW6JtRa7ej0BzZdg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0-rc-69d4b800-20241021",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-rc-69d4b800-20241021.tgz",
-      "integrity": "sha512-ZXBsP/kTDLI9QopUaUgYJhmmAhO8aKz7DCv2Ui2rA9boCfJ/dRRh6BlVidsyb2dPzG01rItdRFQqwbP+x9s5Rg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "0.25.0-rc-69d4b800-20241021"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "19.0.0-rc-69d4b800-20241021"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
@@ -5298,10 +5429,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.25.0-rc-69d4b800-20241021",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-69d4b800-20241021.tgz",
-      "integrity": "sha512-S5AYX/YhMAN6u9AXgKYbZP4U4ZklC6R9Q7HmFSBk7d4DLiHVNxvAvlSvuM4nxFkwOk50MnpfTKQ7UWHXDOc9Eg==",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.6.3",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "@types/react-dom": "^18.0.11",
     "autoprefixer": "^10.4.14",
     "next": "^15.0.1",
+    "next-auth": "^5.0.0-beta.25",
     "postcss": "^8.4.21",
-    "react": "19.0.0-rc-69d4b800-20241021",
-    "react-dom": "19.0.0-rc-69d4b800-20241021",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "tailwindcss": "^3.3.1",
     "typescript": "^5.0.4"
   },

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,2 @@
+import { handlers } from "@/auth"
+export const { GET, POST } = handlers

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,21 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,8 +11,8 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className="h-full bg-gray-100">
-      <body className="min-h-screen flex flex-col items-center justify-center">
+    <html lang="en" className="h-full bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <body className="min-h-screen flex flex-col items-center justify-start">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,12 @@
 import { keyId } from "@stately-cloud/client";
 import { createLink, fetchLinks } from "@/lib/actions";
+import { auth } from "@/auth";
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export default async function Home() {
+  const session = await auth();
   const links = await fetchLinks();
   return (
     <div className="container mx-auto p-4">
@@ -19,7 +21,7 @@ export default async function Home() {
             name="short"
             type="text"
             placeholder="Short name (eg: cnn)"
-            className="border p-2 w-full rounded"
+            className="border p-2 w-full rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 border-gray-300 dark:border-gray-600"
             required
           />
         </div>
@@ -32,7 +34,7 @@ export default async function Home() {
             name="url"
             type="url"
             placeholder="URL (eg: https://cnn.com)"
-            className="border p-2 w-full rounded"
+            className="border p-2 w-full rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 border-gray-300 dark:border-gray-600"
             required
             pattern="https?://.+"
           />
@@ -43,30 +45,37 @@ export default async function Home() {
           </button>
         </div>
       </form>
-      <table className="table-auto w-full">
+      <table className="table-auto w-full mb-8 border-collapse border border-gray-200 dark:border-gray-700">
         <thead>
-          <tr>
-            <th className="px-4 py-2">Short Name</th>
-            <th className="px-4 py-2">URL</th>
-            <th className="px-4 py-2">Created At</th>
+          <tr className="bg-gray-100 dark:bg-gray-800">
+            <th className="px-4 py-2 border-b border-gray-200 dark:border-gray-700 text-left">Short Name</th>
+            <th className="px-4 py-2 border-b border-gray-200 dark:border-gray-700 text-left">URL</th>
+            <th className="px-4 py-2 border-b border-gray-200 dark:border-gray-700 text-left">Created At</th>
           </tr>
         </thead>
         <tbody>
           {links.map((link) => (
-            <tr key={keyId(link.id)} className="border-t">
-              <td className="px-4 py-2">
-                <a href={link.short} className="text-blue-500 underline">
+            <tr key={keyId(link.id)} className="hover:bg-gray-50 dark:hover:bg-gray-900">
+              <td className="px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+                <a href={link.short} className="text-blue-500 dark:text-blue-400 underline">
                   {link.short}
                 </a>
               </td>
-              <td className="px-4 py-2">{link.url}</td>
-              <td className="px-4 py-2">
+              <td className="px-4 py-2 border-b border-gray-200 dark:border-gray-700">{link.url}</td>
+              <td className="px-4 py-2 border-b border-gray-200 dark:border-gray-700">
                 {new Date(Number(link.createdAt)).toLocaleString()}
               </td>
             </tr>
           ))}
         </tbody>
       </table>
+      {session && (
+        <div className="flex justify-between items-center mt-4 p-4 border-t">
+          <div>
+            <p className="text-sm">Signed in as {session?.user?.email || "unknown"}</p>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,11 @@
+import NextAuth from "next-auth"
+import Google from "next-auth/providers/google"
+ 
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [Google],
+  callbacks: {
+    authorized: async ({ auth }) => {
+      return !!auth
+    },
+  },
+})

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,5 @@
+export { auth as middleware } from "@/auth"
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,14 +6,6 @@ const config: Config = {
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  theme: {
-    extend: {
-      colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
-      },
-    },
-  },
   plugins: [],
 };
 export default config;


### PR DESCRIPTION
* Added `next-auth` dependency for basic Google OAuth integration
* Updated keypath to use a hash of the OAuth email, which better reflects real world usage of partitioning the namespace
* Fixed dark mode styles
* Included example configuration (`.env.local.example`)