### PR TITLE
Migrate auth from client_id/secret to access_key

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,5 @@
 # Your StatelyDB credentials.
-STATELY_CLIENT_ID=
-STATELY_CLIENT_SECRET=
+STATELY_ACCESS_KEY=
 
 # Your Stately Store ID. Note that this needs to be the same ID as the one that
 # was used for any schema commands.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "next/typescript"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FStatelyCloud%2Fvercel-starter-template-auth&env=STATELY_STORE_ID,STATELY_CLIENT_SECRET,STATELY_CLIENT_SECRET,NEXTAUTH_URL,AUTH_SECRET,AUTH_GOOGLE_ID,AUTH_GOOGLE_SECRET&envDescription=API%20keys%20and%20Store%20configuration.&envLink=https%3A%2F%2Fdocs.stately.cloud%2Fguides%2Fconnect%2F&skippable-integrations=1)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FStatelyCloud%2Fvercel-starter-template-auth&env=STATELY_STORE_ID,STATELY_ACCESS_KEY,NEXTAUTH_URL,AUTH_SECRET,AUTH_GOOGLE_ID,AUTH_GOOGLE_SECRET&envDescription=API%20keys%20and%20Store%20configuration.&envLink=https%3A%2F%2Fdocs.stately.cloud%2Fguides%2Fconnect%2F&skippable-integrations=1)
 
 # Vercel Starter Template with Auth
 
@@ -35,15 +35,14 @@ This is a sample NextJS webapp that uses StatelyDB.
    ```
 6. For local development, create a `.env.local` file in the root directory with the following content:
    ```
-   STATELY_CLIENT_ID=your_client_id
-   STATELY_CLIENT_SECRET=your_client_secret
+   STATELY_ACCESS_KEY=your_access_key
    STATELY_STORE_ID=12345
    NEXTAUTH_URL=your_base_url
    AUTH_GOOGLE_ID=your_google_oauth_id
    AUTH_GOOGLE_SECRET=your_google_oauth_secret
    AUTH_SECRET=your_auth_secret
    ```
-   Replace `your_client_id`, `your_client_secret`, and `12345` with your actual StatelyDB credentials and store ID.  Replace `your_base_url` with the base url of your app (e.g. `http://localhost:3000` or `https://myapp.vercel.app`).
+   Replace `your_access_key` and `12345` with your actual StatelyDB credentials and store ID.  Replace `your_base_url` with the base url of your app (e.g. `http://localhost:3000` or `https://myapp.vercel.app`).
    
    See `.env.local.example` for more details on the other configuration options.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "go-link-webapp",
       "version": "0.1.0",
       "dependencies": {
-        "@stately-cloud/client": "^0.10.0",
+        "@stately-cloud/client": "^0.17.1",
         "@stately-cloud/schema": "^0.9.0",
         "@types/node": "^18.15.11",
         "@types/react": "^18.0.33",
@@ -84,25 +84,23 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@connectrpc/connect": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.1.tgz",
-      "integrity": "sha512-AupiGDh2Ht0wgslatfdU/Jp8zDPHwvsCrLcChi7Ea3zZT/biSpPMqj8LiaR5ri/EHexZ58jYvtBbTNqCP7H3fg==",
-      "license": "Apache-2.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0.tgz",
+      "integrity": "sha512-Usm8jgaaULANJU8vVnhWssSA6nrZ4DJEAbkNtXSoZay2YD5fDyMukCxu8NEhCvFzfHvrhxhcjttvgpyhOM7xAQ==",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.0.0-rc.1.tgz",
-      "integrity": "sha512-nG+GmyKyZC5ki6L+WHXB2ysKwdMLzR+tkcARLAGX4Ugd7OyB5RWZxqjYYA4Q1M/eWptDzWbSPw29FmF+3LjFlg==",
-      "license": "Apache-2.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.0.0.tgz",
+      "integrity": "sha512-DoI5T+SUvlS/8QBsxt2iDoUg15dSxqhckegrgZpWOtADtmGohBIVbx1UjtWmjLBrP4RdD0FeBw+XyRUSbpKnJQ==",
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.1"
+        "@connectrpc/connect": "2.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1367,17 +1365,19 @@
       "license": "MIT"
     },
     "node_modules/@stately-cloud/client": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@stately-cloud/client/-/client-0.10.0.tgz",
-      "integrity": "sha512-HcJR6bH1nHhqXkh+JydilFHHX5qZgovMVQcfyxWuSSUTsVOODNArFwlqVVLCEiaeLyoO3oJhlABB+lxfEBMz1g==",
-      "license": "Apache-2.0",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@stately-cloud/client/-/client-0.17.1.tgz",
+      "integrity": "sha512-R6P99w1DxNUSztuSMVyvKxnnGeWNcaAyp9+oC0n/sLl8G+zTmT564QBsPHJDHLvrfQVjkTRQqovtdqVcgflXkg==",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "^2.0.0-rc.1",
-        "@connectrpc/connect-node": "^2.0.0-rc.1"
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-node": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0"
       }
     },
     "node_modules/@stately-cloud/schema": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@stately-cloud/client": "^0.10.0",
+    "@stately-cloud/client": "^0.17.1",
     "@stately-cloud/schema": "^0.9.0",
     "@types/node": "^18.15.11",
     "@types/react": "^18.0.33",

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -43,7 +43,7 @@ export async function createLink(formData: FormData) {
       owner: userHash,
     })
   );
-  console.log("Created link:", link); 
+  console.log("Created link:", link);
   revalidatePath("/");
 }
 

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -2,8 +2,8 @@
 
 import { revalidatePath } from "next/cache";
 import { statelyClient } from "./stately";
+import {GoLink} from "./generated/index";
 import { keyPath } from "@stately-cloud/client";
-import { get } from "http";
 import { auth } from "@/auth";
 import crypto from 'crypto';
 
@@ -43,6 +43,7 @@ export async function createLink(formData: FormData) {
       owner: userHash,
     })
   );
+  console.log("Created link:", link); 
   revalidatePath("/");
 }
 
@@ -51,7 +52,7 @@ export async function createLink(formData: FormData) {
  * @param short The short name of the GoLink to retrieve.
  * @returns The GoLink with the given short name, or undefined if not found.
  */
-export async function getLink(short: any) {
+export async function getLink(short: string): Promise<GoLink | undefined> {
   const userHash = await getUserIdentity();
   return statelyClient.get("GoLink", keyPath`/users-${userHash}/s-${short}`);
 }

--- a/src/lib/stately.ts
+++ b/src/lib/stately.ts
@@ -1,10 +1,7 @@
 import { createClient } from "./generated/index.js";
 
-if (!process.env.STATELY_CLIENT_ID) {
-  throw new Error("Missing STATELY_CLIENT_ID");
-}
-if (!process.env.STATELY_CLIENT_SECRET) {
-  throw new Error("Missing STATELY_CLIENT_SECRET");
+if (!process.env.STATELY_ACCESS_KEY) {
+  throw new Error("Missing STATELY_ACCESS_KEY");
 }
 if (!process.env.STATELY_STORE_ID) {
   throw new Error("Missing STATELY_STORE_ID");


### PR DESCRIPTION
## Background
- Now that we've implemented our new and improved access key auth we want to migrate customers over to using access_key so we can remove support for client_id/secret

## Changes
- Swap auth from client_id/secret to access_key
- I also setup the lint config because the linter had never been run and fixed a couple of linter issues

## Testing
- [x] Linter passes